### PR TITLE
Fixed Docker image tag version

### DIFF
--- a/logrotate.daemonset.yaml
+++ b/logrotate.daemonset.yaml
@@ -15,7 +15,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: logrotate
-        image: mumoshu/kube-logrotate:0.1
+        image: mumoshu/kube-logrotate:0.1.0
         resources:
           limits:
             memory: 10Mi


### PR DESCRIPTION
@mumoshu Image version in Docker Hub repo doesn't match the one used here; mush be a typo. Fixing that here.